### PR TITLE
Use HTML5 parsing for agendas of Chamber committees

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "patchwork/utf8": "1.1.*",
         "symfony/css-selector": "2.5.*",
         "symfony/dom-crawler": "2.5.*"
+        "querypath/QueryPath": "dev-master",
     },
     "require-dev": {
         "phpspec/phpspec": "~2.0",

--- a/src/Scrapers/K/CommitteeAgendaList.php
+++ b/src/Scrapers/K/CommitteeAgendaList.php
@@ -197,6 +197,29 @@ class CommitteeAgendaList extends AbstractScraper
     }
 
     /**
+     * Set up a DOM crawler and fill it with the given document.
+     *
+     * @param  string  $document
+     * @param  string  $charset
+     * @return \QueryPath\DOMQuery
+     */
+    protected function buildCrawler($document, $charset = null)
+    {
+        if (is_null($charset)) {
+            $charset = $this->charset;
+        }
+
+        // Convert the content of the document to UTF-8 in case it
+        // uses another encoding (I’m looking at you, ISO-8859-1).
+        if ($charset !== 'UTF-8') {
+            $document = mb_convert_encoding($document, 'UTF-8', $charset);
+        }
+
+        // Create an HTML5-aware crawler.
+        return \html5qp($document);
+    }
+
+    /**
      * Return the appropriate parameters for the document provider.
      *
      * This returns an indexed array of two elements. The first is the

--- a/src/Scrapers/K/CommitteeMeetingList.php
+++ b/src/Scrapers/K/CommitteeMeetingList.php
@@ -24,7 +24,7 @@ class CommitteeMeetingList extends AbstractScraper
 
         foreach ($this->getAgendaAnchors() as $DOMElement) {
 
-            $href = $DOMElement->getAttribute('href');
+            $href = $DOMElement->attr('href');
 
             if (!$matches = $this->matchCommitteeWeek($href)) continue;
 
@@ -39,11 +39,11 @@ class CommitteeMeetingList extends AbstractScraper
      * Return the HTML anchors in the main
      * content area of the document.
      *
-     * @return \Pandemonium\Methuselah\Crawler\Crawler
+     * @return \QueryPath\DOMQuery
      */
     protected function getAgendaAnchors()
     {
-        return $this->getCrawler()->filter('#content a');
+        return $this->getCrawler()->find('#content a');
     }
 
     /**

--- a/src/Scrapers/K/CommitteeMeetingList.php
+++ b/src/Scrapers/K/CommitteeMeetingList.php
@@ -80,6 +80,29 @@ class CommitteeMeetingList extends AbstractScraper
     }
 
     /**
+     * Set up a DOM crawler and fill it with the given document.
+     *
+     * @param  string  $document
+     * @param  string  $charset
+     * @return \QueryPath\DOMQuery
+     */
+    protected function buildCrawler($document, $charset = null)
+    {
+        if (is_null($charset)) {
+            $charset = $this->charset;
+        }
+
+        // Convert the content of the document to UTF-8 in case it
+        // uses another encoding (I’m looking at you, ISO-8859-1).
+        if ($charset !== 'UTF-8') {
+            $document = mb_convert_encoding($document, 'UTF-8', $charset);
+        }
+
+        // Create an HTML5-aware crawler.
+        return \html5qp($document);
+    }
+
+    /**
      * Return the appropriate parameters for the document provider.
      *
      * This returns an indexed array of two elements. The first is the


### PR DESCRIPTION
The source documents now incorrectly use some HTML5 tags. You know, those are fashionable nowadays. So I guess this is great!

However, one thing that is less great is the fact that these tags are used in a way that makes the Symfony DOM crawler unable to work on them any more.

As a fix, this PR introduces a new crawler, coupled with an HTML5-aware parser. This adds lots of computations just to get the same results as before, which is not really cool.
